### PR TITLE
Add CSV export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Extract and export your X (Twitter) bookmarks as Markdown. No AI, no API keys—
 - **Scan Bookmarks**: Extract all tweet URLs from your X Bookmarks page with one click.
 - **Auto-Scroll & Scan All**: Automatically scrolls your bookmarks page to load and extract all bookmarks, even for large accounts.
 - **Download as Markdown**: Export your bookmarks as a clean Markdown list for easy reference or note-taking.
+- **Download as CSV**: Export your bookmarks in a spreadsheet-friendly format.
 - **Copy to Clipboard**: Instantly copy your bookmarks in Markdown format to your clipboard, with a robust fallback if permissions are denied.
 - **Status Bar Feedback**: All actions provide clear, accessible feedback at the top of the popup—no intrusive popups.
 - **Accessibility First**: Full keyboard navigation, ARIA labels, visible focus outlines, and screen reader support.
@@ -44,6 +45,7 @@ Extract and export your X (Twitter) bookmarks as Markdown. No AI, no API keys—
    - For large accounts, click "Auto-Scroll & Scan All" to automatically scroll and load all bookmarks, then extract them.
 4. **Export or Copy**
    - Click "Download .md" to save your bookmarks as a Markdown file.
+   - Click "Download .csv" to save your bookmarks as a CSV file.
    - Or click "Copy to Clipboard" to copy the Markdown list for pasting anywhere. If clipboard permissions are denied, the extension will select the text for you to copy manually.
 
 ## 🛠️ Development

--- a/popup.js
+++ b/popup.js
@@ -146,6 +146,12 @@ class PopupController {
     downloadBtn.disabled = this.scannedTweets.length === 0;
     downloadBtn.addEventListener('click', () => this.downloadMarkdown());
     actions.appendChild(downloadBtn);
+    const csvBtn = document.createElement('button');
+    csvBtn.className = 'export-btn';
+    csvBtn.innerHTML = '<span class="icon-download"></span>Download .csv';
+    csvBtn.disabled = this.scannedTweets.length === 0;
+    csvBtn.addEventListener('click', () => this.downloadCSV());
+    actions.appendChild(csvBtn);
     const copyBtn = document.createElement('button');
     copyBtn.className = 'export-btn';
     copyBtn.innerHTML = '<span class="icon-copy"></span>Copy All';
@@ -279,6 +285,34 @@ class PopupController {
     return md;
   }
 
+  generateCSV() {
+    if (!this.scannedTweets.length) return '';
+    const escapeCSV = (val) => {
+      if (val === undefined || val === null) return '';
+      const str = String(val).replace(/\n/g, ' ');
+      if (/[",]/.test(str)) {
+        return '"' + str.replace(/"/g, '""') + '"';
+      }
+      return str;
+    };
+    let csv = 'Author,Username,Date,Text,Likes,Retweets,Replies,Views,Link\n';
+    this.scannedTweets.forEach(t => {
+      const row = [
+        escapeCSV(t.displayName || ''),
+        escapeCSV('@' + (t.username || '')),
+        escapeCSV(t.dateTime || ''),
+        escapeCSV(t.text || ''),
+        escapeCSV(t.likes || ''),
+        escapeCSV(t.retweets || ''),
+        escapeCSV(t.replies || ''),
+        escapeCSV(t.views || ''),
+        escapeCSV(t.url)
+      ].join(',');
+      csv += row + '\n';
+    });
+    return csv;
+  }
+
   downloadMarkdown() {
     const md = this.generateMarkdown();
     if (!md) return;
@@ -287,6 +321,20 @@ class PopupController {
     const a = document.createElement('a');
     a.href = url;
     a.download = 'x-bookmarks.md';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  downloadCSV() {
+    const csv = this.generateCSV();
+    if (!csv) return;
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'x-bookmarks.csv';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- add CSV export feature in popup
- insert "Download .csv" button
- mention CSV capability in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ec169b3c832b8be97a720091f7b4