### PR TITLE
Add Markdown view toggle in popup

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -265,6 +265,32 @@ body {
   border-bottom: none;
 }
 
+.state-complete .markdown-toggle-btn {
+  margin: 16px 0 0 0;
+  width: 90%;
+  background: #22303C;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  font-size: 15px;
+  padding: 10px 0;
+  cursor: pointer;
+}
+
+.state-complete .markdown-output {
+  width: 90%;
+  margin-top: 8px;
+  height: 120px;
+  background: #192734;
+  color: #fff;
+  border: 1px solid #22303C;
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 13px;
+  padding: 8px;
+  resize: vertical;
+}
+
 .footer {
   padding: 12px 20px;
   background: #15202B;

--- a/popup.js
+++ b/popup.js
@@ -169,6 +169,24 @@ class PopupController {
       });
     }
     container.appendChild(resultsList);
+
+    const mdToggleBtn = document.createElement('button');
+    mdToggleBtn.className = 'markdown-toggle-btn';
+    mdToggleBtn.textContent = 'Show Markdown';
+    const mdArea = document.createElement('textarea');
+    mdArea.className = 'markdown-output';
+    mdArea.value = this.generateMarkdown();
+    mdArea.readOnly = true;
+    mdArea.style.display = 'none';
+    mdArea.addEventListener('focus', () => mdArea.select());
+    mdToggleBtn.addEventListener('click', () => {
+      const isHidden = mdArea.style.display === 'none';
+      mdArea.style.display = isHidden ? 'block' : 'none';
+      mdToggleBtn.textContent = isHidden ? 'Hide Markdown' : 'Show Markdown';
+    });
+    container.appendChild(mdToggleBtn);
+    container.appendChild(mdArea);
+
     this.mainContent.appendChild(container);
   }
 


### PR DESCRIPTION
## Summary
- render Markdown output in popup.js
- add button to toggle Markdown visibility
- style new markdown components

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec179248832bb99904589df47784