### PR TITLE
Fix sendProgress handling

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -5,12 +5,14 @@ class XBookmarkScanner {
   constructor() {
     this.setupMessageListener();
     console.log('[X Extractor] XBookmarkScanner initialized');
-    chrome.runtime.sendMessage({ type: 'progressUpdate', status: 'Content script initialized.' });
+    this.sendProgress('Content script initialized.');
   }
 
   async sendProgress(status) {
     try {
-      chrome.runtime.sendMessage({ type: 'progressUpdate', status });
+      chrome.runtime
+        .sendMessage({ type: 'progressUpdate', status })
+        .catch(() => {});
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
## Summary
- handle the promise returned by `chrome.runtime.sendMessage`
- use `sendProgress` from the constructor

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6878e8b0b6c8832ba30bbe7d2e597838